### PR TITLE
#27 rest connector for Trades API

### DIFF
--- a/connectors/trades-connector/pom.xml
+++ b/connectors/trades-connector/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>com.redhat.ipaas</groupId>
+    <artifactId>connectors</artifactId>
+    <version>0.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <camel.version>2.19.0-SNAPSHOT</camel.version>
+  </properties>
+
+  <artifactId>trades-connector</artifactId>
+  <name>iPaaS Connectors :: Day trade Connector</name>
+  <description>Day trade Connector</description>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Camel BOM -->
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-parent</artifactId>
+        <version>${camel.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-undertow</artifactId>
+    </dependency>
+    <!-- camel-connector -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-connector</artifactId>
+    </dependency>
+
+    <!-- camel and spring boot compiler plugins -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>apt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <!-- generate components meta-data and validate component includes documentation etc -->
+      <plugin>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-package-maven-plugin</artifactId>
+        <version>${camel.version}</version>
+        <executions>
+          <execution>
+            <id>prepare</id>
+            <goals>
+              <goal>prepare-components</goal>
+            </goals>
+            <phase>generate-resources</phase>
+          </execution>
+          <execution>
+            <id>validate</id>
+            <goals>
+              <goal>validate-components</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- generate connector -->
+      <plugin>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-connector-maven-plugin</artifactId>
+        <version>${camel.version}</version>
+        <executions>
+<!--           <execution> -->
+<!--             <id>boot</id> -->
+<!--             <goals> -->
+<!--               <goal>prepare-spring-boot-auto-configuration</goal> -->
+<!--             </goals> -->
+<!--             <configuration> -->
+<!--               we done want license headers -->
+<!--               <includeLicenseHeader>false</includeLicenseHeader> -->
+<!--               we dont camel.connector as prefix -->
+<!--               <configurationPrefix>false</configurationPrefix> -->
+<!--             </configuration> -->
+<!--           </execution> -->
+          <execution>
+            <id>connector</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/connectors/trades-connector/src/main/java/com/redhat/ipaas/connector/daytrade/Trade.java
+++ b/connectors/trades-connector/src/main/java/com/redhat/ipaas/connector/daytrade/Trade.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.connector.daytrade;
+
+public class Trade {
+
+    private String action;
+    private String expiration;
+    private int limit;
+    private int quantity;
+    private String ticker;
+
+    public Trade() {
+
+    }
+
+    public Trade(final String ticker, final int quantity, final String action, final int limit,
+        final String expiration) {
+        this.limit = limit;
+        this.ticker = ticker;
+        this.quantity = quantity;
+        this.action = action;
+        this.expiration = expiration;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getExpiration() {
+        return expiration;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public void setAction(final String action) {
+        this.action = action;
+    }
+
+    public void setExpiration(final String expiration) {
+        this.expiration = expiration;
+    }
+
+    public void setLimit(final int limit) {
+        this.limit = limit;
+    }
+
+    public void setQuantity(final int quantity) {
+        this.quantity = quantity;
+    }
+
+    public void setTicker(final String ticker) {
+        this.ticker = ticker;
+    }
+
+    @Override
+    public String toString() {
+        return "\nlimit   = " + limit + "\nticker  = " + ticker + "\nquantity  = " + quantity + "\nexpires = "
+            + expiration + "\naction  = " + action;
+    }
+}

--- a/connectors/trades-connector/src/main/java/com/redhat/ipaas/connector/daytrade/TradesComponent.java
+++ b/connectors/trades-connector/src/main/java/com/redhat/ipaas/connector/daytrade/TradesComponent.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.connector.daytrade;
+
+import org.apache.camel.component.connector.DefaultConnectorComponent;
+
+public class TradesComponent extends DefaultConnectorComponent {
+
+    public TradesComponent() {
+        super("trades", TradesComponent.class.getName());
+    }
+
+}

--- a/connectors/trades-connector/src/main/resources/META-INF/services/org/apache/camel/component/trades
+++ b/connectors/trades-connector/src/main/resources/META-INF/services/org/apache/camel/component/trades
@@ -1,0 +1,1 @@
+class=com.redhat.ipaas.connector.daytrade.TradesComponent

--- a/connectors/trades-connector/src/main/resources/META-INF/spring.factories
+++ b/connectors/trades-connector/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.redhat.ipaas.connector.daytrade.springboot.TradesConnectorAutoConfiguration

--- a/connectors/trades-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/trades-connector/src/main/resources/camel-connector-schema.json
@@ -1,0 +1,19 @@
+{
+  "component": {
+    "kind": "component",
+    "baseScheme": "rest",
+    "scheme": "trades",
+    "syntax": "trades",
+    "title": "Fetch trades",
+    "description": "Fetch trades from Day trade API server",
+    "label": "http",
+    "deprecated": false,
+    "async": false,
+    "producerOnly": true,
+    "lenientProperties": true,
+    "javaType": "com.redhat.ipaas.connector.daytrade.TradesComponent",
+    "groupId": "com.redhat.ipaas",
+    "artifactId": "trades-connector",
+    "version": "0.3-SNAPSHOT"
+  }
+}

--- a/connectors/trades-connector/src/main/resources/camel-connector.json
+++ b/connectors/trades-connector/src/main/resources/camel-connector.json
@@ -1,0 +1,30 @@
+{
+  "baseScheme" : "rest",
+  "baseGroupId" : "org.apache.camel",
+  "baseArtifactId" : "camel-core",
+  "baseVersion" : "2.19.0-SNAPSHOT",
+  "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
+  "name" : "TradesComponent",
+  "scheme" : "trades",
+  "javaType" : "com.redhat.ipaas.connector.daytrade.TradesComponent",
+  "groupId" : "com.redhat.ipaas",
+  "artifactId" : "trades-connector",
+  "version" : "0.3-SNAPSHOT",
+  "description" : "Fetch trades from Day trade API server",
+  "labels" : [ "http", "daytrade" ],
+  "pattern" : "To",
+  "inputDataType" : "none",
+  "outputDataType" : "java:com.redhat.ipaas.connector.daytrade.Trade",
+  "globalOptions" : [ "host" ],
+  "componentOptions" : [ "host" ],
+  "endpointOptions" : [ "orderId" ],
+  "endpointValues" : {
+    "component" : "undertow",
+    "method" : "GET",
+    "path" : "/apis",
+    "uriTemplate": "/orders/{orderId}",
+    "host" : "http://localhost:8080",
+    "bindingMode" : "json",
+    "outType" : "com.redhat.ipaas.connector.daytrade.Trade"
+  }
+}


### PR DESCRIPTION
@davsclaus @rhuss @jimmidyson can you take a look?

This creates a connector for a single operation on the Trades API REST
resource (day-trade-api[1]), this is done by delegating to Camel REST
component that in turn uses Camel Undertow component to perform the
actual interaction. Camel Jackson component is used to unmarshal the
response received from the service.

This has support for only one REST operation (getTrade[2]), but can be
used as a template to create connectors for other operations.

To initiate the exchange, the incoming message needs to have `orderId`
header set to the ID of the order that needs to be fetched.

The Java class `org.example.ipaas.Trade` has been vendored within the
connector as `com.redhat.ipaas.connector.daytrade.Trade`.

[1] https://github.com/kcbabo/ipaas-demo/tree/master/day-trade-api
[2] https://github.com/kcbabo/ipaas-demo/blob/master/day-trade-api/src/main/java/org/example/ipaas/OrderDesk.java#L33
[3] https://github.com/kcbabo/ipaas-demo/blob/master/day-trade-api/src/main/java/org/example/ipaas/Trade.java