### PR TITLE
fix: Ensure fully qualified class name is used in component registration.

### DIFF
--- a/connectors/http-get-connector/src/main/java/io/syndesis/connector/http/HttpGetComponent.java
+++ b/connectors/http-get-connector/src/main/java/io/syndesis/connector/http/HttpGetComponent.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.connector.DefaultConnectorComponent;
 public class HttpGetComponent extends DefaultConnectorComponent {
     
     public HttpGetComponent() {
-        super("http-get", "HttpGetComponent");
+        super("http-get", HttpGetComponent.class.getName());
     }
 
 }

--- a/connectors/http-post-connector/src/main/java/io/syndesis/connector/http/HttpPostComponent.java
+++ b/connectors/http-post-connector/src/main/java/io/syndesis/connector/http/HttpPostComponent.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.connector.DefaultConnectorComponent;
 public class HttpPostComponent extends DefaultConnectorComponent {
     
     public HttpPostComponent() {
-        super("http-post", "HttpPostComponent");
+        super("http-post", HttpPostComponent.class.getName());
     }
 
 }

--- a/connectors/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/SalesforceUpsertContactComponent.java
+++ b/connectors/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/SalesforceUpsertContactComponent.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.connector.DefaultConnectorComponent;
 public class SalesforceUpsertContactComponent extends DefaultConnectorComponent {
 
     public SalesforceUpsertContactComponent() {
-        super("salesforce-upsert-contact", "SalesforceUpsertContactComponent");
+        super("salesforce-upsert-contact", SalesforceUpsertContactComponent.class.getName());
     }
 
 }

--- a/connectors/timer-connector/src/main/java/io/syndesis/connector/timer/PeriodicTimerComponent.java
+++ b/connectors/timer-connector/src/main/java/io/syndesis/connector/timer/PeriodicTimerComponent.java
@@ -23,7 +23,7 @@ import org.apache.camel.component.connector.DefaultConnectorComponent;
 public class PeriodicTimerComponent extends DefaultConnectorComponent {
     
     public PeriodicTimerComponent() {
-        super("periodic-timer", "PeriodicTimerComponent");
+        super("periodic-timer", PeriodicTimerComponent.class.getName());
     }
 
 }

--- a/connectors/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/TwitterMentionComponent.java
+++ b/connectors/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/TwitterMentionComponent.java
@@ -24,7 +24,7 @@ import org.apache.camel.component.connector.DefaultConnectorComponent;
 public class TwitterMentionComponent extends DefaultConnectorComponent {
     
     public TwitterMentionComponent() {
-        super("twitter-mention", "TwitterMentionComponent");
+        super("twitter-mention", TwitterMentionComponent.class.getName());
 
         setBeforeConsumer(exchange -> {
             exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/java-byte-code");


### PR DESCRIPTION
@iocanel @davsclaus Please take a look and merge/release if it makes sense (which I think it does). This was breaking the verifier.