### PR TITLE
fix: mark endpoint properties as required

### DIFF
--- a/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector.json
@@ -22,5 +22,10 @@
     "sObjectName" : "Contact",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector.json
@@ -22,5 +22,10 @@
     "sObjectName" : "Contact",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector-schema.json
@@ -25,8 +25,8 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector.json
@@ -23,5 +23,13 @@
     "sObjectIdName" : "Id",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName", "sObjectIdName" ]
+  "endpointOptions" : [ "sObjectName", "sObjectIdName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    },
+    "sObjectIdName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector.json
@@ -22,5 +22,10 @@
     "sObjectName" : "Contact",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector-schema.json
@@ -25,8 +25,8 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector.json
@@ -23,5 +23,13 @@
     "sObjectIdName" : "Id",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName", "sObjectIdName" ]
+  "endpointOptions" : [ "sObjectName", "sObjectIdName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    },
+    "sObjectIdName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-on-create-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-on-create-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-on-create-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-create-connector/src/main/resources/camel-connector.json
@@ -19,12 +19,17 @@
   "componentOptions" : [ "loginUrl", "clientId", "clientSecret", "refreshToken", "userName", "password" ],
   "endpointValues" : {
     "updateTopic" : "true",
-    "notifyForFields": "ALL",
-    "notifyForOperationCreate": "true",
-    "notifyForOperationUpdate": "false",
-    "notifyForOperationDelete": "false",
-    "notifyForOperationUndelete": "false",
-    "sObjectClass": "io.syndesis.connector.salesforce.AnyObject"
+    "notifyForFields" : "ALL",
+    "notifyForOperationCreate" : "true",
+    "notifyForOperationUpdate" : "false",
+    "notifyForOperationDelete" : "false",
+    "notifyForOperationUndelete" : "false",
+    "sObjectClass" : "io.syndesis.connector.salesforce.AnyObject"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector.json
@@ -19,12 +19,17 @@
   "componentOptions" : [ "loginUrl", "clientId", "clientSecret", "refreshToken", "userName", "password" ],
   "endpointValues" : {
     "updateTopic" : "true",
-    "notifyForFields": "ALL",
-    "notifyForOperationCreate": "false",
-    "notifyForOperationUpdate": "false",
-    "notifyForOperationDelete": "true",
-    "notifyForOperationUndelete": "false",
-    "sObjectClass": "io.syndesis.connector.salesforce.AnyObject"
+    "notifyForFields" : "ALL",
+    "notifyForOperationCreate" : "false",
+    "notifyForOperationUpdate" : "false",
+    "notifyForOperationDelete" : "true",
+    "notifyForOperationUndelete" : "false",
+    "sObjectClass" : "io.syndesis.connector.salesforce.AnyObject"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-on-update-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-on-update-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-on-update-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-update-connector/src/main/resources/camel-connector.json
@@ -19,12 +19,17 @@
   "componentOptions" : [ "loginUrl", "clientId", "clientSecret", "refreshToken", "userName", "password" ],
   "endpointValues" : {
     "updateTopic" : "true",
-    "notifyForFields": "ALL",
-    "notifyForOperationCreate": "false",
-    "notifyForOperationUpdate": "true",
-    "notifyForOperationDelete": "false",
-    "notifyForOperationUndelete": "false",
-    "sObjectClass": "io.syndesis.connector.salesforce.AnyObject"
+    "notifyForFields" : "ALL",
+    "notifyForOperationCreate" : "false",
+    "notifyForOperationUpdate" : "true",
+    "notifyForOperationDelete" : "false",
+    "notifyForOperationUndelete" : "false",
+    "sObjectClass" : "io.syndesis.connector.salesforce.AnyObject"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector.json
@@ -22,5 +22,10 @@
     "sObjectName" : "Contact",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName" ]
+  "endpointOptions" : [ "sObjectName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector-schema.json
@@ -25,7 +25,7 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "TwitterScreenName__c", "description": "SObject external ID field name" }
+    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "TwitterScreenName__c", "description": "SObject external ID field name" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector.json
@@ -21,5 +21,10 @@
     "operationName" : "upsertSObject",
     "sObjectIdName" : "TwitterScreenName__c"
   },
-  "endpointOptions" : [ "sObjectIdName" ]
+  "endpointOptions" : [ "sObjectIdName" ],
+  "endpointOverrides" : {
+    "sObjectIdName" : {
+      "required" : "true"
+    }
+  }
 }

--- a/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector-schema.json
+++ b/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector-schema.json
@@ -25,8 +25,8 @@
     "password": { "kind": "property", "displayName": "Password", "group": "security", "label": "common,security", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": true, "description": "Password used in OAuth flow to gain access to access token. It's easy to get started with password OAuth flow but in general one should avoid it as it is deemed less secure than other flows. Make sure that you append security token to the end of the password if using one." }
   },
   "properties": {
-    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
-    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": false, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
+    "sObjectIdName": { "kind": "parameter", "displayName": "SObject Id Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Id", "description": "SObject external ID field name" },
+    "sObjectName": { "kind": "parameter", "displayName": "SObject Name", "group": "common", "required": true, "type": "string", "javaType": "java.lang.String", "deprecated": false, "secret": false, "defaultValue": "Contact", "description": "SObject name if required or supported by API" }
   },
   "connectorProperties": {
   }

--- a/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector.json
@@ -23,5 +23,13 @@
     "sObjectIdName" : "Id",
     "rawPayload" : "true"
   },
-  "endpointOptions" : [ "sObjectName", "sObjectIdName" ]
+  "endpointOptions" : [ "sObjectName", "sObjectIdName" ],
+  "endpointOverrides" : {
+    "sObjectName" : {
+      "required" : "true"
+    },
+    "sObjectIdName" : {
+      "required" : "true"
+    }
+  }
 }


### PR DESCRIPTION
Several of Salesforce connector properties were not marked as required,
using `endpointOverrides` these are now properly marked as required.