### PR TITLE
refactor(connectors): exclude Validation API

### DIFF
--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -55,4 +55,22 @@
     <module>trade-insight-top-connector</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Declare camel-salesforce here to remove validation-api from all
+      connectors -->
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-salesforce</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>


### PR DESCRIPTION
`camel-salesforce` pulls in Validation API, which in turns triggers
Spring Boot auto configuration that requires a Validation API
implementation. We don't need it so let's exclude it.