### PR TITLE
fix(salesforce): Redo streaming support

### DIFF
--- a/connectors/salesforce-model/src/main/java/io/syndesis/connector/salesforce/AbstractSalesforceStreamingConnector.java
+++ b/connectors/salesforce-model/src/main/java/io/syndesis/connector/salesforce/AbstractSalesforceStreamingConnector.java
@@ -18,16 +18,12 @@ package io.syndesis.connector.salesforce;
 import java.net.URISyntaxException;
 import java.util.Map;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Component;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.connector.DefaultConnectorComponent;
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
 import org.apache.camel.model.language.ConstantExpression;
 import org.apache.camel.processor.Enricher;
-import org.apache.camel.util.IntrospectionSupport;
 
 public abstract class AbstractSalesforceStreamingConnector extends DefaultConnectorComponent {
     private final String topicPrefix;
@@ -50,7 +46,10 @@ public abstract class AbstractSalesforceStreamingConnector extends DefaultConnec
         options.put(SalesforceEndpointConfig.SOBJECT_QUERY, query);
         options.remove(SalesforceEndpointConfig.SOBJECT_NAME);
 
-        final Enricher enricher = new Enricher(new ConstantExpression("direct:salesforce-streaming-fetch"));
+        final String salesforceComponent = getComponentName() + "-component";
+
+        final Enricher enricher = new Enricher(
+            new ConstantExpression(salesforceComponent + ":getSObject?rawPayload=true&sObjectName=" + sObjectName));
         enricher.setCamelContext(getCamelContext());
 
         setBeforeConsumer(enricher);
@@ -63,30 +62,6 @@ public abstract class AbstractSalesforceStreamingConnector extends DefaultConnec
         final String topic = in.getHeader("CamelSalesforceTopicName", String.class);
 
         return topic.substring(topicPrefix.length(), topic.length() - topicSufix.length());
-    }
-
-    @Override
-    protected void doStart() throws Exception {
-        super.doStart();
-
-        final CamelContext camelContext = getCamelContext();
-        final Component salesforce = camelContext.getComponent("salesforce", true, false);
-        IntrospectionSupport.setProperties(salesforce, getOptions());
-
-        camelContext.addService(salesforce, true, true);
-
-        if (camelContext.getRouteStatus("salesforce-streaming-fetch") == null) {
-            camelContext.addRoutes(new RouteBuilder() {
-                @Override
-                public void configure() throws Exception {
-                    from("direct:salesforce-streaming-fetch").id("salesforce-streaming-fetch")
-                        .setHeader(SalesforceEndpointConfig.SOBJECT_ID, simple("${body.id}"))
-                        .setHeader(SalesforceEndpointConfig.SOBJECT_NAME,
-                            method(AbstractSalesforceStreamingConnector.this, "objectNameFromTopic"))
-                        .to("salesforce:getSObject?rawPayload=true");
-                }
-            });
-        }
     }
 
     protected String topicNameFor(final Map<String, String> options) {

--- a/connectors/salesforce-model/src/main/java/io/syndesis/connector/salesforce/SalesforceIdentifier.java
+++ b/connectors/salesforce-model/src/main/java/io/syndesis/connector/salesforce/SalesforceIdentifier.java
@@ -35,4 +35,9 @@ public class SalesforceIdentifier {
     public void setId(final String id) {
         this.id = id;
     }
+
+    @Override
+    public String toString() {
+        return id;
+    }
 }


### PR DESCRIPTION
Adding a route at the point when the Component is started is not such a
good idea as it leads to ConcurrentModificationException:

    Caused by: java.util.ConcurrentModificationException: null
    	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
    	at java.util.ArrayList$Itr.next(ArrayList.java:851)
    	at org.apache.camel.impl.DefaultCamelContext.startRouteDefinitions(DefaultCamelContext.java:3713)
    	at org.apache.camel.impl.DefaultCamelContext.doStartCamel(DefaultCamelContext.java:3428)
    	at org.apache.camel.impl.DefaultCamelContext.access$000(DefaultCamelContext.java:208)
    	at org.apache.camel.impl.DefaultCamelContext$2.call(DefaultCamelContext.java:3236)
    	at org.apache.camel.impl.DefaultCamelContext$2.call(DefaultCamelContext.java:3232)
    	at org.apache.camel.impl.DefaultCamelContext.doWithDefinedClassLoader(DefaultCamelContext.java:3255)
    	at org.apache.camel.impl.DefaultCamelContext.doStart(DefaultCamelContext.java:3232)

That is a new `RouteDefinition` is added while `DefaultCamelContext`
iterates over existing route `routeDefinitions`.

The new implementation reuses the base component created by the
connector component and cleverly avoids another processor needed to set
the headers (`sObjectName` and `sObjectId`) needed by the Salesforce
component by having `SalesforceIdentifier::toString` return the ID which
will be consumed from the incoming message body and setting
`sObjectName` as endpoint URI property.