### PR TITLE
fix: copy-rename-maven-plugin plugin execution order

### DIFF
--- a/connectors/sql-stored-connector/pom.xml
+++ b/connectors/sql-stored-connector/pom.xml
@@ -168,12 +168,12 @@
         <executions>
           <execution>
             <id>copy-camel-schema</id>
-            <phase>generate-resources</phase>
+            <phase>process-classes</phase>
             <goals>
               <goal>copy</goal>
             </goals>
             <configuration>
-              <sourceFile>${basedir}/src/main/resources/camel-connector-schema.json</sourceFile>
+              <sourceFile>${project.build.directory}/classes/camel-connector-schema.json</sourceFile>
               <destinationFile>${project.build.directory}/classes/io/syndesis/connector/sql-stored-connector.json</destinationFile>
             </configuration>
           </execution>


### PR DESCRIPTION
The `copy-rename-maven-plugin:copy` was coping the unfiltered
`camel-connector-schema.json` to `sql-stored-connector.json` and kept
the `${project.version}` token in the resulting JSON. This changes so
that the filtered resource from `target/classes` is copied after it gets
created.

Fixes #88