### PR TITLE
refactor: upgrade to Camel 2.20.0, few Maven bits

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx512m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dmaven.artifact.threads=8

--- a/connectors/day-trade-get-connector/src/main/resources/camel-connector.json
+++ b/connectors/day-trade-get-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "rest",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
   "name" : "DayTradeGetComponent",
   "scheme" : "day-trade-get",

--- a/connectors/day-trade-place-connector/src/main/resources/camel-connector.json
+++ b/connectors/day-trade-place-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "rest",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
   "name" : "DayTradePlaceComponent",
   "scheme" : "day-trade-place",

--- a/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-create-sobject-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceCreateSObject",
   "scheme" : "salesforce-create-sobject",

--- a/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-delete-sobject-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceDeleteSObject",
   "scheme" : "salesforce-delete-sobject",

--- a/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-delete-sobject-with-id-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceDeleteSObjectWithId",
   "scheme" : "salesforce-delete-sobject-with-id",

--- a/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-get-sobject-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceGetSObject",
   "scheme" : "salesforce-get-sobject",

--- a/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-get-sobject-with-id-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceGetSObjectWithId",
   "scheme" : "salesforce-get-sobject-with-id",

--- a/connectors/salesforce-on-create-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-create-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceOnCreate",
   "scheme" : "salesforce-on-create",

--- a/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-delete-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceOnDelete",
   "scheme" : "salesforce-on-delete",

--- a/connectors/salesforce-on-update-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-on-update-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceOnUpdate",
   "scheme" : "salesforce-on-update",

--- a/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-update-sobject-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceUpdateSObject",
   "scheme" : "salesforce-update-sobject",

--- a/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-upsert-contact-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceUpsertContact",
   "scheme" : "salesforce-upsert-contact-connector",

--- a/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector.json
+++ b/connectors/salesforce-upsert-sobject-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "salesforce",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-salesforce",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.salesforce.SalesforceComponent",
   "name" : "SalesforceUpsertSObject",
   "scheme" : "salesforce-upsert-sobject",

--- a/connectors/sql-stored-connector/pom.xml
+++ b/connectors/sql-stored-connector/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <camel.version>2.20.0.fuse-000091</camel.version>
+    <camel.version>2.20.0</camel.version>
   </properties>
 
   <dependencyManagement>
@@ -236,20 +236,5 @@
 
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
 
 </project>

--- a/connectors/timer-connector/src/main/resources/camel-connector.json
+++ b/connectors/timer-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "timer",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.timer.TimerComponent",
   "name" : "Timer",
   "scheme" : "periodic-timer-connector",

--- a/connectors/trade-insight-buy-connector/src/main/resources/camel-connector.json
+++ b/connectors/trade-insight-buy-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "rest",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
   "name" : "TradeInsightBuy",
   "scheme" : "trade-insight-buy",

--- a/connectors/trade-insight-sell-connector/src/main/resources/camel-connector.json
+++ b/connectors/trade-insight-sell-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "rest",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
   "name" : "TradeInsightSell",
   "scheme" : "trade-insight-sell",

--- a/connectors/trade-insight-top-connector/src/main/resources/camel-connector.json
+++ b/connectors/trade-insight-top-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "rest",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-core",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.rest.RestComponent",
   "name" : "TradeInsightTop",
   "scheme" : "trade-insight-top",

--- a/connectors/twitter-mention-connector/src/main/resources/camel-connector.json
+++ b/connectors/twitter-mention-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "twitter-timeline",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-twitter",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.twitter.timeline.TwitterTimelineComponent",
   "name" : "TwitterMention",
   "scheme" : "twitter-mention-connector",

--- a/connectors/twitter-search-connector/src/main/resources/camel-connector.json
+++ b/connectors/twitter-search-connector/src/main/resources/camel-connector.json
@@ -2,7 +2,7 @@
   "baseScheme" : "twitter-search",
   "baseGroupId" : "org.apache.camel",
   "baseArtifactId" : "camel-twitter",
-  "baseVersion" : "2.20.0.fuse-000106",
+  "baseVersion" : "2.20.0",
   "baseJavaType" : "org.apache.camel.component.twitter.search.TwitterSearchComponent",
   "name" : "TwitterSearch",
   "scheme" : "twitter-search-connector",

--- a/pom.xml
+++ b/pom.xml
@@ -78,33 +78,6 @@
     </snapshotRepository>
   </distributionManagement>
 
-  <repositories>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>    
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>    
-  </pluginRepositories>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -112,7 +85,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring-boot.version>1.5.6.RELEASE</spring-boot.version>
-    <camel.version>2.20.0.fuse-000106</camel.version>
+    <camel.version>2.20.0</camel.version>
 
     <!-- maven plugin version -->
     <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>


### PR DESCRIPTION
Upgrades Camel to 2.20.0 (from Fuse EA) and removes the Fuse EA
repository. Also adds Maven configuration intended to speed up the
build (GC configuration, 8 parallel threads for downloads).